### PR TITLE
 提供订阅活动定时任务

### DIFF
--- a/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/activity/model/ActivityEntryPublish.java
+++ b/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/activity/model/ActivityEntryPublish.java
@@ -1,10 +1,17 @@
 package us.betahouse.haetae.serviceimpl.activity.model;
 
+import us.betahouse.util.common.ToString;
+
 /**
   * @Author kana-cr
   * @Date  2020/8/28 13:23
   **/
-public class ActivityEntryPublish {
+public class ActivityEntryPublish extends ToString {
+
+    /**
+     * 当前订阅的消息 的 唯一凭证
+     */
+   private String activityEntryRecordID;
 
     /**
      * 温馨提示 （备注）
@@ -30,10 +37,13 @@ public class ActivityEntryPublish {
      */
     private String location;
 
+    public String getActivityEntryRecordID() { return activityEntryRecordID; }
+
+    public void setActivityEntryRecordID(String activityEntryRecordID) { this.activityEntryRecordID = activityEntryRecordID; }
+
     public String getNote() { return note; }
 
-    public void setNote(String note) { this.note = note;
-    }
+    public void setNote(String note) { this.note = note; }
     public String getStart() { return start; }
 
     public void setStart(String start) { this.start = start; }

--- a/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/activity/model/ActivityEntryPublish.java
+++ b/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/activity/model/ActivityEntryPublish.java
@@ -1,0 +1,53 @@
+package us.betahouse.haetae.serviceimpl.activity.model;
+
+/**
+  * @Author kana-cr
+  * @Date  2020/8/28 13:23
+  **/
+public class ActivityEntryPublish {
+
+    /**
+     * 温馨提示 （备注）
+     */
+    private String note;
+    /**
+     * 活动开始时间
+     */
+    private String start;
+
+    /**
+     * 活动结束时间
+     */
+    private String end;
+
+    /**
+     * 活动名称
+     */
+    private String activityName;
+
+    /**
+     * 活动地点
+     */
+    private String location;
+
+    public String getNote() { return note; }
+
+    public void setNote(String note) { this.note = note;
+    }
+    public String getStart() { return start; }
+
+    public void setStart(String start) { this.start = start; }
+
+    public String getEnd() { return end; }
+
+    public void setEnd(String end) { this.end = end; }
+
+    public String getActivityName() { return activityName; }
+
+    public void setActivityName(String activityName) { this.activityName = activityName; }
+
+    public String getLocation() { return location; }
+
+    public void setLocation(String location) { this.location = location; }
+
+}

--- a/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/activity/model/AuditMessage.java
+++ b/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/activity/model/AuditMessage.java
@@ -1,0 +1,51 @@
+package us.betahouse.haetae.serviceimpl.activity.model;
+
+import us.betahouse.util.common.ToString;
+
+public class AuditMessage extends ToString {
+
+    /**
+     * 审核结果
+     */
+    private String result;
+
+    /**
+     * 审核内容
+     */
+    private String detail;
+
+    /**
+     * 审核时间
+     */
+    private String auditTime;
+
+    /**
+     * 申请人
+     */
+    private String applicant;
+
+    /**
+     * 备注
+     */
+    private String note;
+
+    public String getResult() { return result; }
+
+    public void setResult(String result) { this.result = result; }
+
+    public String getDetail() { return detail; }
+
+    public void setDetail(String detail) { this.detail = detail; }
+
+    public String getAuditTime() { return auditTime; }
+
+    public void setAuditTime(String auditTime) { this.auditTime = auditTime; }
+
+    public String getApplicant() { return applicant; }
+
+    public void setApplicant(String applicant) { this.applicant = applicant; }
+
+    public String getNote() { return note; }
+
+    public void setNote(String note) { this.note = note; }
+}

--- a/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/activity/service/ActivityEntryService.java
+++ b/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/activity/service/ActivityEntryService.java
@@ -101,4 +101,6 @@ public interface ActivityEntryService {
      * @return
      */
     List<ActivityEntryBO> systemFinishActivityEntry();
+
+
 }

--- a/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/activity/service/ActivityService.java
+++ b/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/activity/service/ActivityService.java
@@ -110,4 +110,12 @@ public interface ActivityService {
      * @param context
      */
     void  assignPastRecord(ActivityManagerRequest request,OperateContext context);
+
+    /**
+     * 校验活动是否存在
+     *  @param request
+     * @param context
+     * @return
+     */
+    Boolean checkActivity(ActivityManagerRequest request, OperateContext context);
 }

--- a/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/activity/service/impl/ActivityEntryServiceImpl.java
+++ b/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/activity/service/impl/ActivityEntryServiceImpl.java
@@ -1,6 +1,5 @@
 package us.betahouse.haetae.serviceimpl.activity.service.impl;
 
-import com.alibaba.fastjson.JSONObject;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -21,17 +20,12 @@ import us.betahouse.haetae.activity.request.ActivityEntryRequest;
 import us.betahouse.haetae.serviceimpl.activity.enums.ActivityEntryStatusType;
 import us.betahouse.haetae.serviceimpl.activity.model.ActivityEntry;
 import us.betahouse.haetae.serviceimpl.activity.model.ActivityEntryList;
-import us.betahouse.haetae.serviceimpl.activity.model.ActivityEntryPublish;
 import us.betahouse.haetae.serviceimpl.activity.service.ActivityEntryService;
 import us.betahouse.haetae.user.dal.service.UserInfoRepoService;
 import us.betahouse.haetae.user.model.basic.UserInfoBO;
-import us.betahouse.util.enums.CommonResultCode;
 import us.betahouse.util.exceptions.BetahouseException;
 import us.betahouse.util.utils.*;
-import us.betahouse.util.wechat.WeChatPublishUtil;
 
-import javax.validation.constraints.AssertTrue;
-import java.text.MessageFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.*;

--- a/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/activity/service/impl/ActivityEntryServiceImpl.java
+++ b/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/activity/service/impl/ActivityEntryServiceImpl.java
@@ -1,5 +1,6 @@
 package us.betahouse.haetae.serviceimpl.activity.service.impl;
 
+import com.alibaba.fastjson.JSONObject;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -20,13 +21,17 @@ import us.betahouse.haetae.activity.request.ActivityEntryRequest;
 import us.betahouse.haetae.serviceimpl.activity.enums.ActivityEntryStatusType;
 import us.betahouse.haetae.serviceimpl.activity.model.ActivityEntry;
 import us.betahouse.haetae.serviceimpl.activity.model.ActivityEntryList;
+import us.betahouse.haetae.serviceimpl.activity.model.ActivityEntryPublish;
 import us.betahouse.haetae.serviceimpl.activity.service.ActivityEntryService;
 import us.betahouse.haetae.user.dal.service.UserInfoRepoService;
 import us.betahouse.haetae.user.model.basic.UserInfoBO;
+import us.betahouse.util.enums.CommonResultCode;
 import us.betahouse.util.exceptions.BetahouseException;
 import us.betahouse.util.utils.*;
+import us.betahouse.util.wechat.WeChatPublishUtil;
 
 import javax.validation.constraints.AssertTrue;
+import java.text.MessageFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.*;
@@ -46,6 +51,8 @@ public class ActivityEntryServiceImpl implements ActivityEntryService {
      * 系统结束标志
      */
     private final static String SYSTEM_FINISH_SIGN = "systemFinish";
+
+
 
     @Autowired
     private ActivityEntryRepoService activityEntryRepoService;
@@ -485,6 +492,7 @@ public class ActivityEntryServiceImpl implements ActivityEntryService {
         }
         return systemFinishActivityEntries;
     }
+
 
 
 }

--- a/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/activity/service/impl/ActivityServiceImpl.java
+++ b/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/activity/service/impl/ActivityServiceImpl.java
@@ -294,6 +294,19 @@ public class ActivityServiceImpl implements ActivityService {
         activityManager.updatePast(request);
     }
 
+    @Override
+    public Boolean checkActivity(ActivityManagerRequest request, OperateContext context) {
+        ActivityBO activity = activityRepoService.queryActivityByActivityId(request.getActivityId());
+        AssertUtil.assertNotNull(activity, "活动不存在");
+        if (StringUtils.equals(activity.getState(),ActivityStateEnum.PUBLISHED.getCode())){
+            //gc
+            activity=null;
+            return true;
+        }
+        activity=null;
+        return false;
+    }
+
     /**
      * 生成权限移除请求
      *
@@ -307,4 +320,5 @@ public class ActivityServiceImpl implements ActivityService {
         permManageRequest.setUserIds(userIds);
         return permManageRequest;
     }
+
 }

--- a/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/common/utils/PublishUtil.java
+++ b/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/common/utils/PublishUtil.java
@@ -1,0 +1,105 @@
+package us.betahouse.haetae.serviceimpl.common.utils;
+
+import cn.hutool.http.HttpUtil;
+import com.alibaba.fastjson.JSONObject;
+import org.apache.commons.lang.StringUtils;
+import us.betahouse.haetae.serviceimpl.activity.model.ActivityEntryPublish;
+import us.betahouse.util.enums.CommonResultCode;
+import us.betahouse.util.exceptions.BetahouseException;
+import us.betahouse.util.utils.AssertUtil;
+import us.betahouse.util.utils.DateUtil;
+import us.betahouse.util.utils.HttpUtils;
+import us.betahouse.util.wechat.WeChatPublishUtil;
+
+import java.text.MessageFormat;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+  * @Author kana-cr
+  * @Date  2020/8/28 13:58
+  */
+public class PublishUtil {
+
+
+    /**
+     * 模板id
+     */
+    private final static String TEMPLATE_ID="oqC6UDgnz6u9FucXj0BPSz7CSn5rZUAT8cq2Ek8Obr4";
+    /**
+     *推送api
+     */
+    private final static String PUBLISH_URL="https://api.weixin.qq.com/cgi-bin/message/subscribe/send?access_token={0}";
+
+    /**
+     * 返回体的错误码
+     */
+    private final static String ERROR_CODE = "errcode";
+
+    /**
+     *
+     * @param openId
+     * @param appId
+     * @param secret
+     * @param activityEntryPublish 活动信息对象
+     * @return
+     */
+    public static Boolean publishActivityByOpenId(String openId  , String appId, String secret, ActivityEntryPublish activityEntryPublish){
+        AssertUtil.assertStringNotBlank(activityEntryPublish.getStart(),"开始时间不能为空");
+        AssertUtil.assertStringNotBlank(activityEntryPublish.getActivityName(),"活动名称不能为空");
+        AssertUtil.assertStringNotBlank(activityEntryPublish.getLocation(),"活动地点不能为空");
+
+
+        String accessToken= WeChatPublishUtil.GetAccessToken(appId,secret);
+        String url = MessageFormat.format(PUBLISH_URL,accessToken);
+
+        StringBuilder publishBuilder = new StringBuilder();
+        publishBuilder.append(DateUtil.getMediumDatesStr(activityEntryPublish.getStart())).append("起");
+        String holdTime=publishBuilder.toString();
+
+        JSONObject jsonObject=new JSONObject();
+        jsonObject.put("touser",openId);
+        jsonObject.put("template_id",TEMPLATE_ID);
+
+        JSONObject data=new JSONObject();
+        JSONObject thing1 = new JSONObject();
+        thing1.put("value",activityEntryPublish.getNote());
+
+        JSONObject thing2 = new JSONObject();
+        thing2.put("value",activityEntryPublish.getActivityName());
+        JSONObject date3 = new JSONObject();
+        date3.put("value",DateUtil.parse_CH(activityEntryPublish.getStart(),"yyyy-MM-dd HH:mm:ss"));
+        JSONObject thing6 = new JSONObject();
+        thing6.put("value",activityEntryPublish.getLocation());
+        JSONObject thing5 = new JSONObject();
+        thing5.put("value", holdTime);
+
+        data.put("thing1", thing1);
+        data.put("thing2",thing2);
+        data.put("date3",date3);
+        data.put("thing6",thing6);
+        data.put("thing5",thing5);
+
+        jsonObject.put("data",data);
+
+        try {
+            String result = HttpUtils.httpPostWithJson(url,jsonObject.toString());
+
+            JSONObject resultJson = JSONObject.parseObject(result);
+            String code = resultJson.getString(ERROR_CODE);
+          //  System.out.println(result);
+            System.out.println(result);
+            //GC
+            jsonObject=null;
+            result=null;
+            publishBuilder=null;
+
+            if (!StringUtils.equals(code,"0"))
+                return false;
+        } catch (Exception e) {
+            throw new BetahouseException(e, CommonResultCode.SYSTEM_ERROR.getCode(), "请求推送失败, 网络异常");
+        }
+
+        return true;
+    }
+}

--- a/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/common/utils/SubscribeUtil.java
+++ b/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/common/utils/SubscribeUtil.java
@@ -1,25 +1,24 @@
 package us.betahouse.haetae.serviceimpl.common.utils;
 
-import cn.hutool.http.HttpUtil;
 import com.alibaba.fastjson.JSONObject;
 import org.apache.commons.lang.StringUtils;
 import us.betahouse.haetae.serviceimpl.activity.model.ActivityEntryPublish;
+import us.betahouse.haetae.serviceimpl.schedule.SubscriptionTask;
 import us.betahouse.util.enums.CommonResultCode;
 import us.betahouse.util.exceptions.BetahouseException;
 import us.betahouse.util.utils.AssertUtil;
 import us.betahouse.util.utils.DateUtil;
 import us.betahouse.util.utils.HttpUtils;
-import us.betahouse.util.wechat.WeChatPublishUtil;
+import us.betahouse.util.wechat.WeChatAccessTokenUtil;
 
 import java.text.MessageFormat;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
   * @Author kana-cr
   * @Date  2020/8/28 13:58
   */
-public class PublishUtil {
+public class SubscribeUtil {
 
 
     /**
@@ -37,20 +36,24 @@ public class PublishUtil {
     private final static String ERROR_CODE = "errcode";
 
     /**
+     * 返回体的错误信息
+     */
+    private final static String ERROR_MESSAGE = "errmsg";
+    /**
      *
      * @param openId
-     * @param appId
-     * @param secret
      * @param activityEntryPublish 活动信息对象
      * @return
      */
-    public static Boolean publishActivityByOpenId(String openId  , String appId, String secret, ActivityEntryPublish activityEntryPublish){
+    private static final ReentrantLock lock = new ReentrantLock();
+
+    public static String publishActivityByOpenId(String openId  , String accessToken, ActivityEntryPublish activityEntryPublish){
         AssertUtil.assertStringNotBlank(activityEntryPublish.getStart(),"开始时间不能为空");
         AssertUtil.assertStringNotBlank(activityEntryPublish.getActivityName(),"活动名称不能为空");
         AssertUtil.assertStringNotBlank(activityEntryPublish.getLocation(),"活动地点不能为空");
 
 
-        String accessToken= WeChatPublishUtil.GetAccessToken(appId,secret);
+        //String accessToken= WeChatAccessTokenUtil.GetAccessToken(appId,secret);
         String url = MessageFormat.format(PUBLISH_URL,accessToken);
 
         StringBuilder publishBuilder = new StringBuilder();
@@ -83,23 +86,30 @@ public class PublishUtil {
         jsonObject.put("data",data);
 
         try {
-            String result = HttpUtils.httpPostWithJson(url,jsonObject.toString());
+            String result = HttpUtils.doPostUseJson(url,jsonObject.toString());
 
             JSONObject resultJson = JSONObject.parseObject(result);
             String code = resultJson.getString(ERROR_CODE);
-          //  System.out.println(result);
-            System.out.println(result);
             //GC
             jsonObject=null;
             result=null;
             publishBuilder=null;
+            if (StringUtils.equals(code,"0")) {
+                return CommonResultCode.SUCCESS.getCode();
+            }else if (StringUtils.equals(code,"42001")){
+                //防止token被连续刷新多次
+                lock.lock();
+                if (StringUtils.equals(accessToken,new SubscriptionTask().GetToken())) {
+                    accessToken = new SubscriptionTask().refreshToken();
+                    return SubscribeUtil.publishActivityByOpenId(openId, accessToken, activityEntryPublish);
+                }
+                lock.unlock();
+            }else if (StringUtils.equals(code,"43101"))
+                return CommonResultCode.FORBIDDEN.getCode();
 
-            if (!StringUtils.equals(code,"0"))
-                return false;
         } catch (Exception e) {
             throw new BetahouseException(e, CommonResultCode.SYSTEM_ERROR.getCode(), "请求推送失败, 网络异常");
         }
-
-        return true;
+        return CommonResultCode.SYSTEM_ERROR.getMessage();
     }
 }

--- a/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/schedule/ScheduleConstant.java
+++ b/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/schedule/ScheduleConstant.java
@@ -20,4 +20,11 @@ public class ScheduleConstant {
      * 每天凌晨2点触发
      */
     public final static String AM_TWO_OF_THE_CLOCK = "0 0 2 * * ?";
+
+    /**
+     * 每天上午7触发
+     */
+    public final static String AM_SEVEN_OF_THE_CLOCK = "0 0 7 * * ?";
+
+
 }

--- a/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/schedule/ScheduleConstant.java
+++ b/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/schedule/ScheduleConstant.java
@@ -21,10 +21,6 @@ public class ScheduleConstant {
      */
     public final static String AM_TWO_OF_THE_CLOCK = "0 0 2 * * ?";
 
-    /**
-     * 每天上午7触发
-     */
-    public final static String AM_SEVEN_OF_THE_CLOCK = "0 0 7 * * ?";
 
 
 }

--- a/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/schedule/ScheduleService.java
+++ b/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/schedule/ScheduleService.java
@@ -22,4 +22,5 @@ public interface ScheduleService {
      * 结束报名
      */
     void finishActivityEntries();
+
 }

--- a/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/schedule/ScheduleServiceImpl.java
+++ b/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/schedule/ScheduleServiceImpl.java
@@ -19,6 +19,7 @@ import us.betahouse.util.utils.CollectionUtils;
 import us.betahouse.util.utils.LoggerUtil;
 
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * 定时任务实现
@@ -39,6 +40,7 @@ public class ScheduleServiceImpl implements ScheduleService {
 
     @Autowired
     private ActivityEntryService activityEntryService;
+
 
     /**
      * 结束活动
@@ -68,4 +70,9 @@ public class ScheduleServiceImpl implements ScheduleService {
             LoggerUtil.info(LOGGER, "系统结束报名, activityEntries={0}", finishActivityEntryList);
         }
     }
+
+
+
+
+
 }

--- a/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/schedule/ScheduleTaskMap.java
+++ b/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/schedule/ScheduleTaskMap.java
@@ -1,0 +1,120 @@
+package us.betahouse.haetae.serviceimpl.schedule;
+
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.support.CronTrigger;
+import org.springframework.stereotype.Component;
+import us.betahouse.haetae.serviceimpl.activity.model.ActivityEntryPublish;
+import us.betahouse.haetae.serviceimpl.schedule.dto.RealTask;
+import us.betahouse.haetae.serviceimpl.schedule.job.SubscriptionTask;
+import us.betahouse.util.utils.DateUtil;
+
+import javax.annotation.PostConstruct;
+import java.text.MessageFormat;
+import java.util.Date;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
+
+@Component
+public class ScheduleTaskMap {
+
+
+    /**
+     * [秒] [分] [小时] [日] [月] [周] [年]
+     */
+    //0 1 2 分别为 小时 日 月
+    private final static String CRON_TEMPLATE ="0 0 {0} {1} {2} ?";
+
+    private final Logger LOGGER = LoggerFactory.getLogger(ScheduleTaskMap.class);
+
+    private final static int ADVANCE_TIME = 2;
+
+    // 静态内部类实现单例模式
+    private ScheduleTaskMap() {
+    }
+
+    private static class  ScheduleTaskMapInstance {
+        private static final  ScheduleTaskMap INSTANCE = new  ScheduleTaskMap();
+    }
+
+    public static  ScheduleTaskMap getInstance() {
+        return  ScheduleTaskMapInstance.INSTANCE;
+    }
+
+    /**
+     * 启动后存储任务列表
+     */
+    private final static Map<String, RealTask> currentHashMap = new ConcurrentHashMap<>();
+
+    /**
+     * 工具类注入bean的方法
+     */
+    @Autowired
+    private ThreadPoolTaskScheduler threadPoolTaskScheduler;
+
+    @PostConstruct
+    public void init() {
+        ScheduleTaskMapInstance.INSTANCE.threadPoolTaskScheduler = this.threadPoolTaskScheduler;
+    }
+
+    /**
+     * 将任务列表处理存入Map容器中
+     *
+     * @param activityEntryPublish
+     * @param openid
+     * @return
+     */
+    public RealTask putMap(ActivityEntryPublish activityEntryPublish , String openid) {
+        Date startTime = DateUtil.parseTime_Database(activityEntryPublish.getStart());
+        //提前两小时
+        int Hour = Integer.valueOf(DateUtil.getHour(startTime));
+        int previousDay = 0;
+        if ( Hour - ADVANCE_TIME < 0){
+            previousDay ++;
+            Hour = Hour + 24 - ADVANCE_TIME;
+        }
+        int day = Integer.parseInt(DateUtil.getDay(startTime));
+        //将订阅发布时间转化成cron表达式 --发布时间在活动开始前三小时
+        //按顺序  时 日 月
+       String cron = MessageFormat.format(CRON_TEMPLATE, String.valueOf(Hour), String.valueOf(day - previousDay),
+              DateUtil.getMonth(startTime));
+
+        RealTask realTask = new RealTask();
+        realTask.setCron(cron);
+        SubscriptionTask task =new SubscriptionTask(activityEntryPublish,openid);
+        realTask.setTask(task);
+
+        LOGGER.info("ThreadPoolTaskScheduler {}", threadPoolTaskScheduler);
+        ScheduledFuture<?> future = threadPoolTaskScheduler.schedule(task, new CronTrigger(cron));
+        realTask.setFuture(future);
+
+        currentHashMap.putIfAbsent(activityEntryPublish.getActivityEntryRecordID(), realTask);
+        LOGGER.info("加入定时任务: {}",realTask.toString());
+
+        return realTask;
+    }
+
+    /**
+     * 根据ID暂停任务,同时在容器中删除
+     * @param id
+     * @return
+     */
+    public RealTask cancelMap(String id) {
+        RealTask task = null;
+        if(currentHashMap.containsKey(id)){
+            task = currentHashMap.get(id);
+            ScheduledFuture<?> future = task.getFuture();
+            if (future != null) {
+                future.cancel(true);
+            }
+            //删除任务
+            currentHashMap.remove(id);
+        }
+        return task;
+    }
+
+}

--- a/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/schedule/ScheduleTaskMap.java
+++ b/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/schedule/ScheduleTaskMap.java
@@ -34,8 +34,7 @@ public class ScheduleTaskMap {
     private final static int ADVANCE_TIME = 2;
 
     // 静态内部类实现单例模式
-    private ScheduleTaskMap() {
-    }
+    private ScheduleTaskMap() { }
 
     private static class  ScheduleTaskMapInstance {
         private static final  ScheduleTaskMap INSTANCE = new  ScheduleTaskMap();

--- a/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/schedule/SubscriptionTask.java
+++ b/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/schedule/SubscriptionTask.java
@@ -1,0 +1,56 @@
+package us.betahouse.haetae.serviceimpl.schedule;
+
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import us.betahouse.haetae.serviceimpl.activity.model.ActivityEntryPublish;
+import us.betahouse.util.utils.DateUtil;
+import us.betahouse.util.wechat.WeChatAccessTokenUtil;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class SubscriptionTask {
+
+    public static String AccessToken ;
+
+    private static String appid;
+
+    private static String secret;
+
+    @Value("${wechat.appId}")
+    public void setAppId(String appId) {    //注意这里的set方法不能是静态的
+        SubscriptionTask.appid = appId;
+    }
+    @Value("${wechat.secret}")
+    public void setSecret(String secret) {    //注意这里的set方法不能是静态的
+        SubscriptionTask.secret = secret;
+    }
+
+
+
+
+   // static final ConcurrentHashMap<String, List<String>> SUBSCRIPTION_CONTAINER =new ConcurrentHashMap<>();
+
+    private final Logger LOGGER = LoggerFactory.getLogger(ScheduleServiceImpl.class);
+
+
+     public static synchronized String GetToken(){
+        if (StringUtils.isEmpty(AccessToken))
+            AccessToken = WeChatAccessTokenUtil.GetAccessToken(appid,secret);
+        return AccessToken;
+     }
+     public static synchronized String refreshToken(){
+         AccessToken = WeChatAccessTokenUtil.GetAccessToken(appid,secret);
+         return AccessToken;
+     }
+
+  //  public static void putSubscriptionTask(ActivityEntryPublish activityEntryPublish){
+
+   // }
+
+
+}

--- a/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/schedule/config/threadPoolConfig.java
+++ b/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/schedule/config/threadPoolConfig.java
@@ -1,0 +1,23 @@
+package us.betahouse.haetae.serviceimpl.schedule.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+public class threadPoolConfig {
+    private final Logger LOGGER = LoggerFactory.getLogger(threadPoolConfig.class);
+
+    @Bean
+    public ThreadPoolTaskScheduler threadPoolTaskScheduler() {
+        ThreadPoolTaskScheduler threadPoolTaskScheduler = new ThreadPoolTaskScheduler();
+        threadPoolTaskScheduler.setPoolSize(20);
+        threadPoolTaskScheduler.setThreadNamePrefix("threadPoolTaskScheduler-");
+        threadPoolTaskScheduler.setWaitForTasksToCompleteOnShutdown(true);
+        threadPoolTaskScheduler.setAwaitTerminationSeconds(60);
+        LOGGER.info("已经载入ThreadPoolTaskScheduler的Bean对象,对象为{}",threadPoolTaskScheduler);
+        return threadPoolTaskScheduler;
+    }
+}

--- a/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/schedule/dto/RealTask.java
+++ b/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/schedule/dto/RealTask.java
@@ -1,0 +1,30 @@
+package us.betahouse.haetae.serviceimpl.schedule.dto;
+
+
+
+import us.betahouse.util.common.ToString;
+
+import java.util.concurrent.ScheduledFuture;
+
+
+public class RealTask extends ToString {
+	private String cron;
+	
+	private Object task;
+	
+	private ScheduledFuture<?> future;
+
+	public String getCron() { return cron; }
+
+	public void setCron(String cron) { this.cron = cron; }
+
+	public Object getTask() { return task; }
+
+	public void setTask(Object task) { this.task = task; }
+
+	public ScheduledFuture<?> getFuture() { return future; }
+
+	public void setFuture(ScheduledFuture<?> future) { this.future = future; }
+
+
+}

--- a/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/schedule/job/SubscriptionTask.java
+++ b/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/schedule/job/SubscriptionTask.java
@@ -1,0 +1,38 @@
+package us.betahouse.haetae.serviceimpl.schedule.job;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import us.betahouse.haetae.serviceimpl.activity.model.ActivityEntryPublish;
+import us.betahouse.haetae.serviceimpl.common.utils.SubscribeUtil;
+import us.betahouse.haetae.serviceimpl.schedule.ScheduleTaskMap;
+import us.betahouse.haetae.serviceimpl.schedule.manager.AccessTokenManage;
+
+/**
+  * @Author kana-cr
+  * @Date  2020/8/29 16:38
+  * 定时任务类
+  **/
+public class SubscriptionTask implements Runnable {
+
+    private final Logger LOGGER = LoggerFactory.getLogger(SubscriptionTask.class);
+
+    private ActivityEntryPublish activityEntryPublish;
+
+    private String openid;
+
+    /**
+     * 定时消费任务 消费后不论成功失败都删除该任务
+     */
+    @Override
+    public void run() {
+        SubscribeUtil.publishActivityByOpenId(openid,AccessTokenManage.GetToken(),activityEntryPublish);
+        //订阅发布后删除容器中的该任务
+        LOGGER.info("消费订阅消息，订阅id为 {}",activityEntryPublish.getActivityEntryRecordID());
+        ScheduleTaskMap.getInstance().cancelMap(activityEntryPublish.getActivityEntryRecordID() );
+    }
+
+    public SubscriptionTask(ActivityEntryPublish activityEntryPublish, String openid) {
+        this.activityEntryPublish = activityEntryPublish;
+        this.openid = openid;
+    }
+}

--- a/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/schedule/manager/AccessTokenManage.java
+++ b/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/schedule/manager/AccessTokenManage.java
@@ -1,21 +1,16 @@
-package us.betahouse.haetae.serviceimpl.schedule;
+package us.betahouse.haetae.serviceimpl.schedule.manager;
 
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import us.betahouse.haetae.serviceimpl.activity.model.ActivityEntryPublish;
-import us.betahouse.util.utils.DateUtil;
 import us.betahouse.util.wechat.WeChatAccessTokenUtil;
 
-import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
-
 @Component
-public class SubscriptionTask {
+public class AccessTokenManage {
 
-    public static String AccessToken ;
+    private static String AccessToken ;
 
     private static String appid;
 
@@ -23,19 +18,14 @@ public class SubscriptionTask {
 
     @Value("${wechat.appId}")
     public void setAppId(String appId) {    //注意这里的set方法不能是静态的
-        SubscriptionTask.appid = appId;
+        AccessTokenManage.appid = appId;
     }
+
     @Value("${wechat.secret}")
     public void setSecret(String secret) {    //注意这里的set方法不能是静态的
-        SubscriptionTask.secret = secret;
+        AccessTokenManage.secret = secret;
     }
 
-
-
-
-   // static final ConcurrentHashMap<String, List<String>> SUBSCRIPTION_CONTAINER =new ConcurrentHashMap<>();
-
-    private final Logger LOGGER = LoggerFactory.getLogger(ScheduleServiceImpl.class);
 
 
      public static synchronized String GetToken(){
@@ -48,9 +38,7 @@ public class SubscriptionTask {
          return AccessToken;
      }
 
-  //  public static void putSubscriptionTask(ActivityEntryPublish activityEntryPublish){
 
-   // }
 
 
 }

--- a/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/schedule/manager/AccessTokenManage.java
+++ b/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/schedule/manager/AccessTokenManage.java
@@ -7,6 +7,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import us.betahouse.util.wechat.WeChatAccessTokenUtil;
 
+import java.util.concurrent.locks.ReentrantLock;
+
 @Component
 public class AccessTokenManage {
 
@@ -26,11 +28,17 @@ public class AccessTokenManage {
         AccessTokenManage.secret = secret;
     }
 
+    private static final ReentrantLock lock = new ReentrantLock();
 
+     public static String GetToken(){
+            if (StringUtils.isEmpty(AccessToken)) {
+                lock.lock();
+                if (AccessToken == null) {
+                    AccessToken = WeChatAccessTokenUtil.GetAccessToken(appid, secret);
+                }
+                lock.unlock();
+            }
 
-     public static synchronized String GetToken(){
-        if (StringUtils.isEmpty(AccessToken))
-            AccessToken = WeChatAccessTokenUtil.GetAccessToken(appid,secret);
         return AccessToken;
      }
      public static synchronized String refreshToken(){

--- a/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/user/service/UserService.java
+++ b/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/user/service/UserService.java
@@ -9,6 +9,7 @@ import us.betahouse.haetae.serviceimpl.user.request.CommonUserRequest;
 import us.betahouse.haetae.user.model.CommonUser;
 import us.betahouse.haetae.user.model.basic.perm.PermBO;
 import us.betahouse.haetae.user.model.basic.perm.RoleBO;
+import us.betahouse.haetae.user.model.basic.perm.UserBO;
 
 import java.util.Map;
 
@@ -115,5 +116,14 @@ public interface UserService {
      * @param context
      */
     void modifyUserMajorAndClassAndGrade(CommonUserRequest request, OperateContext context);
+
+    /**
+     * 通过唯一的userid查询用户信息
+     *
+     * @param userId
+     * @param context
+     * @return
+     */
+    UserBO queryByUserId(String userId, OperateContext context);
 }
 

--- a/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/user/service/impl/UserServiceImpl.java
+++ b/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/user/service/impl/UserServiceImpl.java
@@ -165,4 +165,5 @@ public class UserServiceImpl implements UserService {
     public void modifyUserMajorAndClassAndGrade(CommonUserRequest request, OperateContext context) {
         userBasicService.modifyMajorAndClassAndGrade(request.getUserId(), request.getUserInfoBO().getMajor(), request.getUserInfoBO().getClassId(), request.getUserInfoBO().getGrade());
     }
+
 }

--- a/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/user/service/impl/UserServiceImpl.java
+++ b/biz/impl/src/main/java/us/betahouse/haetae/serviceimpl/user/service/impl/UserServiceImpl.java
@@ -166,4 +166,9 @@ public class UserServiceImpl implements UserService {
         userBasicService.modifyMajorAndClassAndGrade(request.getUserId(), request.getUserInfoBO().getMajor(), request.getUserInfoBO().getClassId(), request.getUserInfoBO().getGrade());
     }
 
+    @Override
+    public UserBO queryByUserId(String userId, OperateContext context) {
+      return userRepoService.queryByUserId(userId);
+    }
+
 }

--- a/core/activity/src/main/java/us/betahouse/haetae/activity/dal/model/ActivityEntryRecordDO.java
+++ b/core/activity/src/main/java/us/betahouse/haetae/activity/dal/model/ActivityEntryRecordDO.java
@@ -60,10 +60,7 @@ public class ActivityEntryRecordDO extends BaseDO{
      */
     private String choose;
 
-    /**
-     *是否订阅活动开始消息
-     */
-     private String subscribe;
+
 
     public String getActivityEntryRecordId() {
         return activityEntryRecordId;
@@ -125,7 +122,5 @@ public class ActivityEntryRecordDO extends BaseDO{
         this.choose = choose;
     }
 
-    public String getSubscribe() { return subscribe; }
 
-    public void setSubscribe(String subscribe) { this.subscribe = subscribe; }
 }

--- a/core/activity/src/main/java/us/betahouse/haetae/activity/dal/model/ActivityEntryRecordDO.java
+++ b/core/activity/src/main/java/us/betahouse/haetae/activity/dal/model/ActivityEntryRecordDO.java
@@ -60,6 +60,10 @@ public class ActivityEntryRecordDO extends BaseDO{
      */
     private String choose;
 
+    /**
+     *是否订阅活动开始消息
+     */
+     private String subscribe;
 
     public String getActivityEntryRecordId() {
         return activityEntryRecordId;
@@ -120,4 +124,8 @@ public class ActivityEntryRecordDO extends BaseDO{
     public void setChoose(String choose) {
         this.choose = choose;
     }
+
+    public String getSubscribe() { return subscribe; }
+
+    public void setSubscribe(String subscribe) { this.subscribe = subscribe; }
 }

--- a/core/activity/src/main/java/us/betahouse/haetae/activity/model/basic/ActivityBO.java
+++ b/core/activity/src/main/java/us/betahouse/haetae/activity/model/basic/ActivityBO.java
@@ -137,14 +137,6 @@ public class ActivityBO extends ToString {
         }
     }
 
-    /**
-     * 判断是否活动处于发布状态，并且在今天开始 (用于推送功能)
-     *
-     */
-    public  boolean canPublish(){
-
-        return  StringUtils.equals(state, ActivityStateEnum.PUBLISHED.getCode()) && DateUtil.isToday(start);
-    }
 
     /**
      * 判断是否可以结束

--- a/core/activity/src/main/java/us/betahouse/haetae/activity/model/basic/ActivityBO.java
+++ b/core/activity/src/main/java/us/betahouse/haetae/activity/model/basic/ActivityBO.java
@@ -138,9 +138,16 @@ public class ActivityBO extends ToString {
     }
 
     /**
-     * 判断是否可以结束
+     * 判断是否活动处于发布状态，并且在今天开始 (用于推送功能)
      *
-     * @return
+     */
+    public  boolean canPublish(){
+
+        return  StringUtils.equals(state, ActivityStateEnum.PUBLISHED.getCode()) && DateUtil.isToday(start);
+    }
+
+    /**
+     * 判断是否可以结束
      */
     public boolean canFinish() {
         // 活动手动重启 系统不会去结束

--- a/core/activity/src/main/java/us/betahouse/haetae/activity/model/basic/ActivityEntryRecordBO.java
+++ b/core/activity/src/main/java/us/betahouse/haetae/activity/model/basic/ActivityEntryRecordBO.java
@@ -51,6 +51,12 @@ public class ActivityEntryRecordBO extends ToString {
     private String choose;
 
     /**
+     *是否订阅活动开始消息
+     */
+    private String subscribe;
+
+
+    /**
      * 拓展信息
      */
     private Map<String, String> extInfo = new HashMap<>();
@@ -125,6 +131,11 @@ public class ActivityEntryRecordBO extends ToString {
     public void setChoose(String choose) {
         this.choose = choose;
     }
+
+    public String getSubscribe() { return subscribe; }
+
+    public void setSubscribe(String subscribe) { this.subscribe = subscribe; }
+
 
     public Map<String, String> getExtInfo() {
         return extInfo;

--- a/core/activity/src/main/java/us/betahouse/haetae/activity/model/basic/ActivityEntryRecordBO.java
+++ b/core/activity/src/main/java/us/betahouse/haetae/activity/model/basic/ActivityEntryRecordBO.java
@@ -50,11 +50,6 @@ public class ActivityEntryRecordBO extends ToString {
      */
     private String choose;
 
-    /**
-     *是否订阅活动开始消息
-     */
-    private String subscribe;
-
 
     /**
      * 拓展信息
@@ -131,10 +126,6 @@ public class ActivityEntryRecordBO extends ToString {
     public void setChoose(String choose) {
         this.choose = choose;
     }
-
-    public String getSubscribe() { return subscribe; }
-
-    public void setSubscribe(String subscribe) { this.subscribe = subscribe; }
 
 
     public Map<String, String> getExtInfo() {

--- a/core/activity/src/main/java/us/betahouse/haetae/activity/request/ActivityEntryRecordRequest.java
+++ b/core/activity/src/main/java/us/betahouse/haetae/activity/request/ActivityEntryRecordRequest.java
@@ -45,10 +45,6 @@ public class ActivityEntryRecordRequest extends BaseRequest{
      */
     private String choose;
 
-    /**
-     *是否订阅活动开始消息
-     */
-    private String subscribe;
 
     public String getActivityEntryRecordId() {
         return activityEntryRecordId;
@@ -106,7 +102,5 @@ public class ActivityEntryRecordRequest extends BaseRequest{
         this.choose = choose;
     }
 
-    public String getSubscribe() { return subscribe; }
 
-    public void setSubscribe(String subscribe) { this.subscribe = subscribe; }
 }

--- a/core/activity/src/main/java/us/betahouse/haetae/activity/request/ActivityEntryRecordRequest.java
+++ b/core/activity/src/main/java/us/betahouse/haetae/activity/request/ActivityEntryRecordRequest.java
@@ -45,6 +45,11 @@ public class ActivityEntryRecordRequest extends BaseRequest{
      */
     private String choose;
 
+    /**
+     *是否订阅活动开始消息
+     */
+    private String subscribe;
+
     public String getActivityEntryRecordId() {
         return activityEntryRecordId;
     }
@@ -100,4 +105,8 @@ public class ActivityEntryRecordRequest extends BaseRequest{
     public void setChoose(String choose) {
         this.choose = choose;
     }
+
+    public String getSubscribe() { return subscribe; }
+
+    public void setSubscribe(String subscribe) { this.subscribe = subscribe; }
 }

--- a/core/user/src/main/java/us/betahouse/haetae/user/dal/service/UserRepoService.java
+++ b/core/user/src/main/java/us/betahouse/haetae/user/dal/service/UserRepoService.java
@@ -85,4 +85,5 @@ public interface UserRepoService {
      * @return
      */
     UserBO queryBySessionId(String sessionId);
+
 }

--- a/util/src/main/java/us/betahouse/util/utils/DateUtil.java
+++ b/util/src/main/java/us/betahouse/util/utils/DateUtil.java
@@ -23,11 +23,17 @@ public class DateUtil {
 
     private static final String YEAR_TIME = "yyyy";
 
+    private static final String HOUR_TIME = "HH";
+
+    private static final String MINUTE_TIME = "mm";
+
+    private static final String MONTH_TIME= "MM";
+
+    private static final String DAY = "dd";
+
     private static final String MONTH_DAY = "MMdd";
 
     private static final String YEAR_MONTH_DAY="yyyy-MM-dd";
-
-    private static final String DAY = "dd";
 
     private static final String TIME_DESCRIPTION = "yyyy年MM月dd日 HH:mm";
 
@@ -50,6 +56,7 @@ public class DateUtil {
 
     private static String getMediumDatesStr(Date date) { return format(date, MEDIUM_TIME); }
 
+    public static Date parseTime_Database(String str){return parse(str,TIME_DATABASE);}
     /**
      * 获取年份
      *
@@ -66,13 +73,18 @@ public class DateUtil {
      * @param date
      * @return
      */
-    public static String getMonthDay(Date date) {
-        return format(date, MONTH_DAY);
-    }
+    public static String getMonthDay(Date date) { return format(date, MONTH_DAY); }
 
-    public static String getYearMonthDay(Date date){
-        return format(date, YEAR_MONTH_DAY);
-    }
+    /**
+     * 获取月份
+     * @param date
+     * @return
+     */
+
+    public static String getMonth(Date date) { return format(date, MONTH_TIME); }
+
+
+    public static String getYearMonthDay(Date date){ return format(date, YEAR_MONTH_DAY); }
     /**
      * 获取日
      *
@@ -82,6 +94,16 @@ public class DateUtil {
     public static String getDay(Date date) {
         return format(date, DAY);
     }
+
+    /**
+     * 获取小时
+     */
+    public static String getHour(Date date) { return format(date, HOUR_TIME); }
+
+    /**
+     * 获取分钟
+     */
+    public static String getMinute(Date date) { return format(date, MINUTE_TIME); }
 
     /**
      * 格式化时间
@@ -153,35 +175,5 @@ public class DateUtil {
        }
 
    }
-    /**
-     * 判断日期是不是今天内
-     *
-     * @param inputDate
-     * @return
-     */
-    public static boolean isToday(Date inputDate){
-        boolean flag = false;
-        //获取当前系统时间
-        long longDate = System.currentTimeMillis();
-        Date nowDate = new Date(longDate);
-        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-        String format = dateFormat.format(nowDate);
-        String subDate = format.substring(0, 10);
-        //定义每天的24h时间范围
-        String beginTime = subDate + " 00:00:00";
-        String endTime = subDate + " 23:59:59";
-        Date BeginTime = null;
-        Date EndTime = null;
-        try {
-            BeginTime = dateFormat.parse(beginTime);
-            EndTime = dateFormat.parse(endTime);
 
-        } catch (ParseException e) {
-            throw new IllegalArgumentException("日期转换失败");
-        }
-        if(inputDate.after(BeginTime) && inputDate.before(EndTime)) {
-            flag = true;
-        }
-        return flag;
-    }
 }

--- a/util/src/main/java/us/betahouse/util/utils/DateUtil.java
+++ b/util/src/main/java/us/betahouse/util/utils/DateUtil.java
@@ -4,6 +4,7 @@
  */
 package us.betahouse.util.utils;
 
+import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -16,6 +17,8 @@ import java.util.Date;
  */
 public class DateUtil {
 
+    private static final String MEDIUM_TIME = "MM月dd日 ";
+
     private static final String SHORT_TIME = "yyyyMMddHHmmss";
 
     private static final String YEAR_TIME = "yyyy";
@@ -26,12 +29,12 @@ public class DateUtil {
 
     private static final String DAY = "dd";
 
+    private static final String TIME_DESCRIPTION = "yyyy年MM月dd日 HH:mm";
 
+    private static final String TIME_DATABASE = "yyyy-MM-dd HH:mm:ss";
     /**
      * 获取短时间字符串
-     *
      * @param date
-     * @return
      */
     public static String getShortDatesStr(Date date) {
         return format(date, SHORT_TIME);
@@ -42,6 +45,10 @@ public class DateUtil {
     }
 
 
+   //该方法用于数据库中的日期转换为MEDIUM_TIME格式
+    public static String getMediumDatesStr(String str) { return getMediumDatesStr(parse(str,TIME_DATABASE)); }
+
+    private static String getMediumDatesStr(Date date) { return format(date, MEDIUM_TIME); }
 
     /**
      * 获取年份
@@ -129,5 +136,52 @@ public class DateUtil {
             return false;
         }
         return true;
+    }
+
+
+    /**
+     * 转换成 yyyy年MM月dd日 形式
+     */
+   public static String parse_CH(String dateStr,String format){
+       DateFormat dateFormat = new SimpleDateFormat(format);
+       try {
+           Date date = dateFormat.parse(dateStr);
+           DateFormat CHFormat=new SimpleDateFormat(TIME_DESCRIPTION);
+        return  CHFormat.format(date);
+       } catch (ParseException e) {
+           throw new IllegalArgumentException("日期转换失败");
+       }
+
+   }
+    /**
+     * 判断日期是不是今天内
+     *
+     * @param inputDate
+     * @return
+     */
+    public static boolean isToday(Date inputDate){
+        boolean flag = false;
+        //获取当前系统时间
+        long longDate = System.currentTimeMillis();
+        Date nowDate = new Date(longDate);
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        String format = dateFormat.format(nowDate);
+        String subDate = format.substring(0, 10);
+        //定义每天的24h时间范围
+        String beginTime = subDate + " 00:00:00";
+        String endTime = subDate + " 23:59:59";
+        Date BeginTime = null;
+        Date EndTime = null;
+        try {
+            BeginTime = dateFormat.parse(beginTime);
+            EndTime = dateFormat.parse(endTime);
+
+        } catch (ParseException e) {
+            throw new IllegalArgumentException("日期转换失败");
+        }
+        if(inputDate.after(BeginTime) && inputDate.before(EndTime)) {
+            flag = true;
+        }
+        return flag;
     }
 }

--- a/util/src/main/java/us/betahouse/util/utils/DateUtil.java
+++ b/util/src/main/java/us/betahouse/util/utils/DateUtil.java
@@ -38,6 +38,8 @@ public class DateUtil {
     private static final String TIME_DESCRIPTION = "yyyy年MM月dd日 HH:mm";
 
     private static final String TIME_DATABASE = "yyyy-MM-dd HH:mm:ss";
+
+    private static final String TIME_MONTH_DAY = "MM月dd日";
     /**
      * 获取短时间字符串
      * @param date
@@ -52,7 +54,7 @@ public class DateUtil {
 
 
    //该方法用于数据库中的日期转换为MEDIUM_TIME格式
-    public static String getMediumDatesStr(String str) { return getMediumDatesStr(parse(str,TIME_DATABASE)); }
+    public static String getMediumDatesStr(String str) { return getMediumDatesStr(parse(str,TIME_MONTH_DAY)); }
 
     private static String getMediumDatesStr(Date date) { return format(date, MEDIUM_TIME); }
 

--- a/util/src/main/java/us/betahouse/util/utils/HttpUtils.java
+++ b/util/src/main/java/us/betahouse/util/utils/HttpUtils.java
@@ -237,7 +237,12 @@ public class HttpUtils {
         }
 
     }
-    public static String httpPostWithJson(String url, String json) {
+
+    /**
+     *当要发送复杂json对象时 使用
+     *
+     */
+    public static String doPostUseJson(String url, String json) {
         String result = "";
         HttpPost httpPost = new HttpPost(url);
         CloseableHttpClient httpClient = HttpClients.createDefault();

--- a/util/src/main/java/us/betahouse/util/utils/HttpUtils.java
+++ b/util/src/main/java/us/betahouse/util/utils/HttpUtils.java
@@ -4,6 +4,12 @@
  */
 package us.betahouse.util.utils;
 
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.BasicResponseHandler;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+
 import java.io.*;
 import java.net.*;
 import java.util.Iterator;
@@ -230,5 +236,29 @@ public class HttpUtils {
             connection.setReadTimeout(socketTimeout);
         }
 
+    }
+    public static String httpPostWithJson(String url, String json) {
+        String result = "";
+        HttpPost httpPost = new HttpPost(url);
+        CloseableHttpClient httpClient = HttpClients.createDefault();
+        try {
+            BasicResponseHandler handler = new BasicResponseHandler();
+            StringEntity entity = new StringEntity(json, "utf-8");//解决中文乱码问题
+            entity.setContentEncoding("UTF-8");
+            entity.setContentType("application/json");
+            httpPost.setEntity(entity);
+            result = httpClient.execute(httpPost, handler);
+            return result;
+        } catch (Exception e) {
+            e.printStackTrace();
+
+        } finally {
+            try {
+                httpClient.close();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+        return result;
     }
 }

--- a/util/src/main/java/us/betahouse/util/wechat/WeChatAccessTokenUtil.java
+++ b/util/src/main/java/us/betahouse/util/wechat/WeChatAccessTokenUtil.java
@@ -14,7 +14,7 @@ import java.util.Map;
   * @Author kana-cr
   * @Date  2020/8/28 12:06
   **/
-public class WeChatPublishUtil {
+public class WeChatAccessTokenUtil {
 
 
     /**

--- a/util/src/main/java/us/betahouse/util/wechat/WeChatLoginUtil.java
+++ b/util/src/main/java/us/betahouse/util/wechat/WeChatLoginUtil.java
@@ -11,6 +11,8 @@ import us.betahouse.util.utils.AssertUtil;
 import us.betahouse.util.utils.HttpUtils;
 
 import java.text.MessageFormat;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * 微信openId请求工具
@@ -26,16 +28,18 @@ public class WeChatLoginUtil {
      */
     private final static String OPEN_ID_URL_TEMPLATE = "https://api.weixin.qq.com/sns/jscode2session?appid={0}&secret={1}&js_code={2}&grant_type=authorization_code";
 
+
     /**
      * 返回体的openId
      */
     private final static String OPEN_ID = "openid";
-
+    
     /**
      * 返回体的错误码
      */
     private final static String ERROR_CODE = "errcode";
 
+    
     /**
      * 获取openId
      *
@@ -59,4 +63,6 @@ public class WeChatLoginUtil {
 
         return openId;
     }
+
+
 }

--- a/util/src/main/java/us/betahouse/util/wechat/WeChatPublishUtil.java
+++ b/util/src/main/java/us/betahouse/util/wechat/WeChatPublishUtil.java
@@ -1,0 +1,65 @@
+package us.betahouse.util.wechat;
+
+import com.alibaba.fastjson.JSONObject;
+import us.betahouse.util.enums.CommonResultCode;
+import us.betahouse.util.exceptions.BetahouseException;
+import us.betahouse.util.utils.AssertUtil;
+import us.betahouse.util.utils.HttpUtils;
+
+import java.text.MessageFormat;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+  * @Author kana-cr
+  * @Date  2020/8/28 12:06
+  **/
+public class WeChatPublishUtil {
+
+
+    /**
+     * 获取accessToken的url模板
+     */
+    private final static String ACCESS_TOKEN_URL_TEMPLATE = "https://api.weixin.qq.com/cgi-bin/token?grant_type=client_credential";
+
+    /**
+     * 返回体的access_token
+     */
+    private final static String ACCESS_TOKEN="access_token";
+
+
+    /**
+     * 返回体的错误码
+     */
+    private final static String ERROR_CODE = "errcode";
+
+    /**
+     * 返回体的openId
+     */
+    private final static String OPEN_ID = "openid";
+
+    /**
+     * 获取accessToken
+     * @return
+     */
+    public static String GetAccessToken(String appId,String secret){
+        Map<String,Object> parameterMap=new HashMap<>(2);
+        parameterMap.put("appid",appId);
+        parameterMap.put("secret",secret);
+        String result;
+        try {
+            result = HttpUtils.doPost(ACCESS_TOKEN_URL_TEMPLATE,parameterMap);
+        } catch (Exception e) {
+            throw new BetahouseException(e, CommonResultCode.SYSTEM_ERROR.getCode(), "微信服务器请求失败, 网络异常");
+        }
+        JSONObject jsonObject = JSONObject.parseObject(result);
+
+        String accessToken = jsonObject.getString(ACCESS_TOKEN);
+        AssertUtil.assertStringNotBlank(accessToken, CommonResultCode.SYSTEM_ERROR.getCode(), MessageFormat.format("微信服务器请求失败:{0}", jsonObject.getString(ERROR_CODE)));
+        //gc
+        parameterMap=null;
+        return accessToken;
+    }
+
+
+}

--- a/web/src/main/java/us/betahouse/HaetaeWebApplication.java
+++ b/web/src/main/java/us/betahouse/HaetaeWebApplication.java
@@ -3,10 +3,13 @@ package us.betahouse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.context.annotation.ImportResource;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
+
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 import us.betahouse.haetae.serviceimpl.common.init.InitService;
 
@@ -18,6 +21,7 @@ import javax.annotation.PostConstruct;
 @ImportResource(locations = {"classpath:spring/user.xml", "classpath:spring/biz-service.xml"})
 @SpringBootApplication
 @EnableScheduling
+@EnableAsync
 public class HaetaeWebApplication {
 
     @Autowired
@@ -36,4 +40,5 @@ public class HaetaeWebApplication {
         app = this;
         app.initService = this.initService;
     }
+
 }

--- a/web/src/main/java/us/betahouse/haetae/controller/activity/ActivityController.java
+++ b/web/src/main/java/us/betahouse/haetae/controller/activity/ActivityController.java
@@ -331,7 +331,7 @@ public class ActivityController {
                 if (StringUtils.equals(CommonResultCode.FORBIDDEN.getCode(),result)){
                     return  RestResultUtil.buildSuccessResult( request , "用户未允许订阅该消息");
                 }
-                return RestResultUtil.buildSuccessResult(request , "订阅信息已发布");;
+                return RestResultUtil.buildSuccessResult(request , "订阅信息已发布");
             }
 
             });

--- a/web/src/main/java/us/betahouse/haetae/controller/activity/ActivityController.java
+++ b/web/src/main/java/us/betahouse/haetae/controller/activity/ActivityController.java
@@ -164,6 +164,35 @@ public class ActivityController {
     }
 
     /**
+     * 校验活动是否存在
+     *
+     * @param request
+     * @param httpServletRequest
+     * @return
+     */
+    @GetMapping("/check")
+    @Log(loggerName = LoggerName.WEB_DIGEST)
+    public Result<ActivityBO> checkActivity(ActivityRestRequest request,HttpServletRequest httpServletRequest){
+        return RestOperateTemplate.operate(LOGGER, "校验活动是否存在且处于发布状态", request, new RestOperateCallBack<ActivityBO>() {
+            @Override
+            public void before() {
+                AssertUtil.assertNotNull(request, RestResultCode.ILLEGAL_PARAMETERS.getCode(), "请求体不能为空");
+                AssertUtil.assertStringNotBlank(request.getActivityId(), RestResultCode.ILLEGAL_PARAMETERS.getCode(), "活动id不能为空");
+            }
+            @Override
+            public Result<ActivityBO> execute() {
+                OperateContext context = new OperateContext();
+                context.setOperateIP(IPUtil.getIpAddr(httpServletRequest));
+                ActivityManagerRequest activityManagerRequest = ActivityManagerRequestBuilder.getInstance()
+                        .withActivityId(request.getActivityId()).build();
+                Boolean ifActivityExist=activityService.checkActivity(activityManagerRequest,context);
+                return ifActivityExist ? RestResultUtil.buildSuccessResult("活动存在并处于发布状态"):RestResultUtil.buildFailResult("活动不处于发布状态");
+            }
+        });
+    }
+
+
+    /**
      * 操作活动
      *
      * @param request

--- a/web/src/main/java/us/betahouse/haetae/controller/user/UserActivityEntryController.java
+++ b/web/src/main/java/us/betahouse/haetae/controller/user/UserActivityEntryController.java
@@ -236,10 +236,6 @@ public class UserActivityEntryController {
                        BeanUtils.copyProperties(request,activityEntryPublish);
                        String token = AccessTokenManage.GetToken();
                        String result = SubscribeUtil.publishActivityByOpenId(openid, token, activityEntryPublish);
-                       if (StringUtils.equals(CommonResultCode.ILLEGAL_PARAMETERS.getCode(),result) ){
-                           token = AccessTokenManage.refreshToken();
-                           result = SubscribeUtil.publishActivityByOpenId(openid, token, activityEntryPublish);
-                       }
                        if (StringUtils.equals(CommonResultCode.FORBIDDEN.getCode(),result)){
                            return  RestResultUtil.buildSuccessResult(activityEntryPublish , "用户未允许订阅该消息");
                        }

--- a/web/src/main/java/us/betahouse/haetae/controller/user/UserController.java
+++ b/web/src/main/java/us/betahouse/haetae/controller/user/UserController.java
@@ -404,4 +404,6 @@ public class UserController {
             }
         });
     }
+
+
 }

--- a/web/src/main/java/us/betahouse/haetae/model/activity/request/ActivitySubscribeRestRequest.java
+++ b/web/src/main/java/us/betahouse/haetae/model/activity/request/ActivitySubscribeRestRequest.java
@@ -11,11 +11,6 @@ public class ActivitySubscribeRestRequest extends RestRequest {
     private String activityEntryRecordID ;
 
     /**
-     * 用户的openid
-     */
-    private String openid;
-
-    /**
      * 温馨提示 （备注）
      */
     private String note;
@@ -42,10 +37,6 @@ public class ActivitySubscribeRestRequest extends RestRequest {
     public String getActivityEntryRecordID() { return activityEntryRecordID; }
 
     public void setActivityEntryRecordID(String activityEntryRecordID) { this.activityEntryRecordID = activityEntryRecordID; }
-
-    public String getOpenid() { return openid; }
-
-    public void setOpenid(String openid) { this.openid = openid; }
 
     public String getNote() { return note; }
 

--- a/web/src/main/java/us/betahouse/haetae/model/activity/request/ActivitySubscribeRestRequest.java
+++ b/web/src/main/java/us/betahouse/haetae/model/activity/request/ActivitySubscribeRestRequest.java
@@ -4,6 +4,12 @@ import us.betahouse.haetae.common.RestRequest;
 
 public class ActivitySubscribeRestRequest extends RestRequest {
 
+
+    /**
+     * 活动报名记录ID 当前订阅的消息的唯一凭证
+     */
+    private String activityEntryRecordID ;
+
     /**
      * 用户的openid
      */
@@ -32,6 +38,10 @@ public class ActivitySubscribeRestRequest extends RestRequest {
      * 活动地点
      */
     private String location;
+
+    public String getActivityEntryRecordID() { return activityEntryRecordID; }
+
+    public void setActivityEntryRecordID(String activityEntryRecordID) { this.activityEntryRecordID = activityEntryRecordID; }
 
     public String getOpenid() { return openid; }
 

--- a/web/src/main/java/us/betahouse/haetae/model/activity/request/ActivitySubscribeRestRequest.java
+++ b/web/src/main/java/us/betahouse/haetae/model/activity/request/ActivitySubscribeRestRequest.java
@@ -1,0 +1,61 @@
+package us.betahouse.haetae.model.activity.request;
+
+import us.betahouse.haetae.common.RestRequest;
+
+public class ActivitySubscribeRestRequest extends RestRequest {
+
+    /**
+     * 用户的openid
+     */
+    private String openid;
+
+    /**
+     * 温馨提示 （备注）
+     */
+    private String note;
+    /**
+     * 活动开始时间
+     */
+    private String start;
+
+    /**
+     * 活动结束时间
+     */
+    private String end;
+
+    /**
+     * 活动名称
+     */
+    private String activityName;
+
+    /**
+     * 活动地点
+     */
+    private String location;
+
+    public String getOpenid() { return openid; }
+
+    public void setOpenid(String openid) { this.openid = openid; }
+
+    public String getNote() { return note; }
+
+    public void setNote(String note) { this.note = note;
+    }
+    public String getStart() { return start; }
+
+    public void setStart(String start) { this.start = start; }
+
+    public String getEnd() { return end; }
+
+    public void setEnd(String end) { this.end = end; }
+
+    public String getActivityName() { return activityName; }
+
+    public void setActivityName(String activityName) { this.activityName = activityName; }
+
+    public String getLocation() { return location; }
+
+    public void setLocation(String location) { this.location = location; }
+
+
+}

--- a/web/src/main/java/us/betahouse/haetae/model/activity/request/AuditRestRequest.java
+++ b/web/src/main/java/us/betahouse/haetae/model/activity/request/AuditRestRequest.java
@@ -1,0 +1,51 @@
+package us.betahouse.haetae.model.activity.request;
+
+import us.betahouse.haetae.common.RestRequest;
+
+public class AuditRestRequest extends RestRequest {
+
+    /**
+     * 审核结果
+     */
+    private String result;
+
+    /**
+     * 审核内容
+     */
+    private String detail;
+
+    /**
+     * 审核时间
+     */
+    private String auditTime;
+
+    /**
+     * 申请人
+     */
+    private String applicant;
+
+    /**
+     * 备注
+     */
+    private String note;
+
+    public String getResult() { return result; }
+
+    public void setResult(String result) { this.result = result; }
+
+    public String getDetail() { return detail; }
+
+    public void setDetail(String detail) { this.detail = detail; }
+
+    public String getAuditTime() { return auditTime; }
+
+    public void setAuditTime(String auditTime) { this.auditTime = auditTime; }
+
+    public String getApplicant() { return applicant; }
+
+    public void setApplicant(String applicant) { this.applicant = applicant; }
+
+    public String getNote() { return note; }
+
+    public void setNote(String note) { this.note = note; }
+}

--- a/web/src/test/java/us/betahouse/haetae/controller/activity/SubscriptionTaskTest.java
+++ b/web/src/test/java/us/betahouse/haetae/controller/activity/SubscriptionTaskTest.java
@@ -1,0 +1,12 @@
+package us.betahouse.haetae.controller.activity;
+
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class SubscriptionTaskTest {
+
+
+}

--- a/web/src/test/java/us/betahouse/haetae/serviceimpl/activity/service/ActivityPublishTest.java
+++ b/web/src/test/java/us/betahouse/haetae/serviceimpl/activity/service/ActivityPublishTest.java
@@ -1,0 +1,63 @@
+package us.betahouse.haetae.serviceimpl.activity.service;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import us.betahouse.haetae.activity.manager.ActivityManager;
+import us.betahouse.haetae.activity.model.basic.ActivityBO;
+import us.betahouse.haetae.serviceimpl.activity.model.ActivityEntryPublish;
+import us.betahouse.haetae.serviceimpl.common.utils.PublishUtil;
+import us.betahouse.util.utils.CollectionUtils;
+import us.betahouse.util.utils.DateUtil;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class ActivityPublishTest {
+
+    @Autowired
+    ActivityService activityService;
+    @Autowired
+    ActivityManager activityManager;
+    @Autowired
+    ActivityEntryService activityEntryService;
+
+    private String APP_ID = "wxabf0acc20f14bbba";
+
+    private String SECRET ="d85d7d457b94d5feb17ba31b6b8f24fd";
+    /**
+     * 每天早上七点 查询是否有活动需要发布
+     *
+     */
+    @Test
+    public void GetActivityStartTime(){
+        List<Date> activityStartTimeList;
+        activityStartTimeList =
+                CollectionUtils.toStream(activityManager.findAll())
+              .filter(Objects::nonNull)
+              .filter(ActivityBO::canPublish).map(ActivityBO::getStart)
+                .collect(Collectors.collectingAndThen(Collectors.toList(),
+                        Collections::unmodifiableList));
+        System.out.println(activityStartTimeList);
+    }
+
+   @Test
+    public void PublishActivityToday(){
+       ActivityEntryPublish publish = new ActivityEntryPublish();
+       publish.setStart("2020-08-28 13:00:00");
+       publish.setEnd("2020-08-29 15:00:00");
+       publish.setActivityName("测试活动");
+       publish.setLocation("测试地点");
+       publish.setNote("备注提示");
+       PublishUtil.publishActivityByOpenId("oe38G5ju57Z57WXsqBygQUQmw-CQ",APP_ID,SECRET,publish);
+   }
+
+//todo 通过accessToken TemplateId 以及自定义的Data(发布内容) 来申请进行发布订阅消息
+}

--- a/web/src/test/java/us/betahouse/haetae/serviceimpl/activity/service/ActivityPublishTest.java
+++ b/web/src/test/java/us/betahouse/haetae/serviceimpl/activity/service/ActivityPublishTest.java
@@ -1,6 +1,5 @@
 package us.betahouse.haetae.serviceimpl.activity.service;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,13 +8,10 @@ import org.springframework.test.context.junit4.SpringRunner;
 import us.betahouse.haetae.activity.manager.ActivityManager;
 import us.betahouse.haetae.activity.model.basic.ActivityBO;
 import us.betahouse.haetae.serviceimpl.activity.model.ActivityEntryPublish;
-import us.betahouse.haetae.serviceimpl.common.utils.PublishUtil;
+import us.betahouse.haetae.serviceimpl.common.utils.SubscribeUtil;
 import us.betahouse.util.utils.CollectionUtils;
-import us.betahouse.util.utils.DateUtil;
 
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 @RunWith(SpringRunner.class)
@@ -29,6 +25,7 @@ public class ActivityPublishTest {
     @Autowired
     ActivityEntryService activityEntryService;
 
+
     private String APP_ID = "wxabf0acc20f14bbba";
 
     private String SECRET ="d85d7d457b94d5feb17ba31b6b8f24fd";
@@ -39,13 +36,13 @@ public class ActivityPublishTest {
     @Test
     public void GetActivityStartTime(){
         List<Date> activityStartTimeList;
-        activityStartTimeList =
+       /* activityStartTimeList =
                 CollectionUtils.toStream(activityManager.findAll())
               .filter(Objects::nonNull)
               .filter(ActivityBO::canPublish).map(ActivityBO::getStart)
                 .collect(Collectors.collectingAndThen(Collectors.toList(),
-                        Collections::unmodifiableList));
-        System.out.println(activityStartTimeList);
+                        Collections::unmodifiableList));*/
+       // System.out.println(activityStartTimeList);
     }
 
    @Test
@@ -56,7 +53,7 @@ public class ActivityPublishTest {
        publish.setActivityName("测试活动");
        publish.setLocation("测试地点");
        publish.setNote("备注提示");
-       PublishUtil.publishActivityByOpenId("oe38G5ju57Z57WXsqBygQUQmw-CQ",APP_ID,SECRET,publish);
+      // SubscribeUtil.publishActivityByOpenId("oe38G5ju57Z57WXsqBygQUQmw-CQ",APP_ID,SECRET,publish);
    }
 
 //todo 通过accessToken TemplateId 以及自定义的Data(发布内容) 来申请进行发布订阅消息

--- a/web/src/test/java/us/betahouse/haetae/serviceimpl/user/service/impl/UserServiceImplTest.java
+++ b/web/src/test/java/us/betahouse/haetae/serviceimpl/user/service/impl/UserServiceImplTest.java
@@ -1,0 +1,84 @@
+package us.betahouse.haetae.serviceimpl.user.service.impl;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import us.betahouse.haetae.activity.dal.service.ActivityEntryRecordRepoService;
+import us.betahouse.haetae.activity.manager.ActivityManager;
+import us.betahouse.haetae.activity.model.basic.ActivityEntryRecordBO;
+import us.betahouse.haetae.serviceimpl.activity.model.ActivityEntryPublish;
+import us.betahouse.haetae.serviceimpl.activity.service.ActivityEntryService;
+import us.betahouse.haetae.serviceimpl.common.utils.SubscribeUtil;
+import us.betahouse.haetae.serviceimpl.user.service.UserService;
+import us.betahouse.haetae.user.dal.service.UserRepoService;
+import us.betahouse.haetae.user.manager.UserManager;
+import us.betahouse.haetae.user.model.basic.perm.UserBO;
+
+import java.util.*;
+
+
+/**
+  * @Author kana-cr
+  * @Date  2020/8/28 16:29
+  **/
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class UserServiceImplTest {
+
+    @Autowired
+    ActivityManager activityManager;
+    @Autowired
+    UserService userService;
+    @Autowired
+    UserManager userManager;
+    @Autowired
+    UserRepoService userRepoService;
+    @Autowired
+    ActivityEntryService activityEntryService;
+    @Autowired
+    ActivityEntryRecordRepoService activityEntryRecordRepoService;
+
+    //作为定时器 早晨七点定时发布订阅消息
+    @Test
+    public void GetOpenIdByUserId(){
+
+        //查询当天开始的活动的报名信息
+       /* List<String> activityIdList;
+        activityIdList = CollectionUtils.toStream(activityManager.findAll())
+                        .filter(Objects::nonNull)
+                        .filter(ActivityBO::canPublish).map(ActivityBO::getActivityId)
+                        .collect(Collectors.collectingAndThen(Collectors.toList(),
+                                Collections::unmodifiableList));
+        System.out.println(activityIdList);*/
+
+       //获取所有 可能有订阅用户的活动ID
+        List<String> activityEntryIdList =new ArrayList<>();
+        //查询填充 ...
+        activityEntryIdList.add("202008241401218227825410062020");
+        //根据活动id集 来查询当前活动下的报名人
+        for (String id: activityEntryIdList) {
+            List<ActivityEntryRecordBO> list = activityEntryRecordRepoService.findAllByActivityEntryId(id);
+            for (ActivityEntryRecordBO activityEntryRecordBO:list ) {
+                //sub字段 或者别的方式判断没有订阅 就不推送
+
+        //根据userid查询openid
+      UserBO userBO = userRepoService.queryByUserId(activityEntryRecordBO.getUserId());
+      String openid = userBO.getOpenId();
+      userBO=null;
+        ActivityEntryPublish activityEntryPublish=new ActivityEntryPublish();
+       // BeanUtils.copyProperties(new ActivityEntryBO(),activityEntryPublish);
+        //手动装配对象
+      //根据openid 预先的templateId 去发布订阅的消息
+   //    Boolean ifTrue = SubscribeUtil.publishActivityByOpenId(openid,"appid","secret",activityEntryPublish);
+      //false的话 retry一定次数（5-10次）
+
+                activityEntryRecordBO=null;
+        }
+            list=null;
+    }
+        activityEntryIdList=null;
+
+    }
+}

--- a/web/src/test/java/us/betahouse/util/utils/WeChatAccessTokenAndPublishUtil.java
+++ b/web/src/test/java/us/betahouse/util/utils/WeChatAccessTokenAndPublishUtil.java
@@ -2,11 +2,9 @@ package us.betahouse.util.utils;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
-import us.betahouse.util.wechat.WeChatLoginUtil;
-import us.betahouse.util.wechat.WeChatPublishUtil;
+import us.betahouse.util.wechat.WeChatAccessTokenUtil;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
@@ -19,13 +17,13 @@ public class WeChatAccessTokenAndPublishUtil {
 
     @Test
     public void WeChatAccessTokenGet(){
-       String accessToken = WeChatPublishUtil.GetAccessToken(APP_ID,SECRET);
+       String accessToken = WeChatAccessTokenUtil.GetAccessToken(APP_ID,SECRET);
         System.out.println(accessToken);
     }
 
     @Test
     public void WeChatPublish(){
-        String accessToken = WeChatPublishUtil.GetAccessToken(APP_ID,SECRET);
+        String accessToken = WeChatAccessTokenUtil.GetAccessToken(APP_ID,SECRET);
 
     }
 

--- a/web/src/test/java/us/betahouse/util/utils/WeChatAccessTokenAndPublishUtil.java
+++ b/web/src/test/java/us/betahouse/util/utils/WeChatAccessTokenAndPublishUtil.java
@@ -1,0 +1,32 @@
+package us.betahouse.util.utils;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import us.betahouse.util.wechat.WeChatLoginUtil;
+import us.betahouse.util.wechat.WeChatPublishUtil;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class WeChatAccessTokenAndPublishUtil {
+
+    private String APP_ID = "wxabf0acc20f14bbba";
+
+
+    private String SECRET ="d85d7d457b94d5feb17ba31b6b8f24fd";
+
+    @Test
+    public void WeChatAccessTokenGet(){
+       String accessToken = WeChatPublishUtil.GetAccessToken(APP_ID,SECRET);
+        System.out.println(accessToken);
+    }
+
+    @Test
+    public void WeChatPublish(){
+        String accessToken = WeChatPublishUtil.GetAccessToken(APP_ID,SECRET);
+
+    }
+
+}


### PR DESCRIPTION
提供了报名活动订阅接口，以及添加了实时发布的测试接口 增加执行定时任务的线程池和存放任务的容器，任务在执行后不论消费成功还是失败一律删除。

添加了小程序的accessToken的存放类。

 提供检测活动存在接口